### PR TITLE
fix(CubeReal_ver2_0_0):fix operation limit and remove all default pram

### DIFF
--- a/docs/usage_cube.md
+++ b/docs/usage_cube.md
@@ -305,7 +305,7 @@ public void TurnOnLightWithScenario(int repeatCount, Cube.LightOperation[] opera
   - 範囲 : 0~255
 - operations
   - 定義 : 命令配列
-  - 個数 : 1~59
+  - 個数 : 1~29
 - order
   - 定義 : [命令の優先度](sys_cube.md#4-命令送信)
   - 種類 : Weak, Strong
@@ -370,7 +370,7 @@ public void PlaySound(int repeatCount, SoundOperation[] operations, ORDER_TYPE o
   - 範囲 : 0~255
 - operations
   - 定義 : 命令配列
-  - 個数 : 1~29
+  - 個数 : 1~59
 - order
   - 定義 : [命令の優先度](sys_cube.md#4-命令送信)
   - 種類 : Weak, Strong

--- a/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Real/Versions/CubeReal_ver2_0_0.cs
+++ b/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Real/Versions/CubeReal_ver2_0_0.cs
@@ -147,7 +147,7 @@ namespace toio
         public override void TurnOnLightWithScenario(int repeatCount, LightOperation[] operations, ORDER_TYPE order)
         {
 #if !RELEASE
-            if (59 < operations.Length)
+            if (29 < operations.Length)
             {
                 Debug.LogErrorFormat("[Cube.TurnOnLightWithScenario]最大発光数を超えました. operations.Length={0}", operations.Length);
             }
@@ -155,7 +155,7 @@ namespace toio
             if (!this.isConnected) { return; }
 
             repeatCount = Mathf.Clamp(repeatCount, 0, 255);
-            var operation_length = Mathf.Clamp(operations.Length, 0, 59);
+            var operation_length = Mathf.Clamp(operations.Length, 0, 29);
 
             byte[] buff = new byte[3 + operation_length * 6];
             buff[0] = 4;
@@ -219,7 +219,8 @@ namespace toio
         public override void PlaySound(int repeatCount, SoundOperation[] operations, ORDER_TYPE order)
         {
 #if !RELEASE
-            if (29 < operations.Length)
+            // v2.0.0に限り58以下
+            if (58 < operations.Length)
             {
                 Debug.LogErrorFormat("[Cube.playSound]最大メロディ数を超えました. operations.Length={0}", operations.Length);
             }
@@ -227,7 +228,7 @@ namespace toio
             if (!this.isConnected) { return; }
 
             repeatCount = Mathf.Clamp(repeatCount, 0, 255);
-            var operation_length = Mathf.Clamp(operations.Length, 0, 29);
+            var operation_length = Mathf.Clamp(operations.Length, 0, 58);
 
             byte[] buff = new byte[3 + operation_length * 3];
             buff[0] = 3;
@@ -252,6 +253,13 @@ namespace toio
         /// <param name="order">命令の優先度</param>
         public override void PlaySound(byte[] buff, ORDER_TYPE order)
         {
+#if !RELEASE
+            // v2.0.0に限り58以下
+            if (58 < buff[2])
+            {
+                Debug.LogErrorFormat("[Cube.playSound]最大メロディ数を超えました. Length={0}", buff[2]);
+            }
+#endif
             if (!this.isConnected) { return; }
 
             this.Request(CHARACTERISTIC_SOUND, buff, true, order, "playSound");

--- a/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Real/Versions/CubeReal_ver2_0_0.cs
+++ b/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Real/Versions/CubeReal_ver2_0_0.cs
@@ -75,7 +75,7 @@ namespace toio
         /// <param name="right">右モーター速度</param>
         /// <param name="durationMs">持続時間(ミリ秒)</param>
         /// <param name="order">命令の優先度</param>
-        public override void Move(int left, int right, int durationMs, ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void Move(int left, int right, int durationMs, ORDER_TYPE order)
         {
 #if !RELEASE
             if (2550 < durationMs)
@@ -115,7 +115,7 @@ namespace toio
         /// <param name="blue">青色の強さ</param>
         /// <param name="durationMs">持続時間(ミリ秒)</param>
         /// <param name="order">命令の優先度</param>
-        public override void TurnLedOn(int red, int green, int blue, int durationMs, ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void TurnLedOn(int red, int green, int blue, int durationMs, ORDER_TYPE order)
         {
 #if !RELEASE
             if (2550 < durationMs)
@@ -144,7 +144,7 @@ namespace toio
         /// <param name="repeatCount">繰り返し回数</param>
         /// <param name="operations">命令配列</param>
         /// <param name="order">命令の優先度</param>
-        public override void TurnOnLightWithScenario(int repeatCount, LightOperation[] operations, ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void TurnOnLightWithScenario(int repeatCount, LightOperation[] operations, ORDER_TYPE order)
         {
 #if !RELEASE
             if (59 < operations.Length)
@@ -197,7 +197,7 @@ namespace toio
         /// <param name="soundId">サウンドID</param>
         /// <param name="volume">音量</param>
         /// <param name="order">命令の優先度</param>
-        public override void PlayPresetSound(int soundId, int volume = 255, ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void PlayPresetSound(int soundId, int volume, ORDER_TYPE order)
         {
             if (!this.isConnected) { return; }
 
@@ -216,7 +216,7 @@ namespace toio
         /// <param name="repeatCount">繰り返し回数</param>
         /// <param name="operations">命令配列</param>
         /// <param name="order">命令の優先度</param>
-        public override void PlaySound(int repeatCount, SoundOperation[] operations, ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void PlaySound(int repeatCount, SoundOperation[] operations, ORDER_TYPE order)
         {
 #if !RELEASE
             if (29 < operations.Length)
@@ -250,7 +250,7 @@ namespace toio
         /// </summary>
         /// <param name="buff">命令プロトコル</param>
         /// <param name="order">命令の優先度</param>
-        public override void PlaySound(byte[] buff, ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void PlaySound(byte[] buff, ORDER_TYPE order)
         {
             if (!this.isConnected) { return; }
 
@@ -262,7 +262,7 @@ namespace toio
         /// https://toio.github.io/toio-spec/docs/ble_sound#再生の停止
         /// </summary>
         /// <param name="order">命令の優先度</param>
-        public override void StopSound(ORDER_TYPE order = ORDER_TYPE.Weak)
+        public override void StopSound(ORDER_TYPE order)
         {
             if (!this.isConnected) { return; }
 
@@ -278,7 +278,7 @@ namespace toio
         /// </summary>
         /// <param name="angle">傾き検知の閾値</param>
         /// <param name="order">命令の優先度</param>
-        public override void ConfigSlopeThreshold(int _angle, ORDER_TYPE order = ORDER_TYPE.Strong)
+        public override void ConfigSlopeThreshold(int _angle, ORDER_TYPE order)
         {
             if (!this.isConnected) { return; }
 
@@ -298,7 +298,7 @@ namespace toio
         /// </summary>
         /// <param name="level">衝突検知の閾値</param>
         /// <param name="order">命令の優先度</param>
-        public override void ConfigCollisionThreshold(int level, ORDER_TYPE order = ORDER_TYPE.Strong)
+        public override void ConfigCollisionThreshold(int level, ORDER_TYPE order)
         {
             if (!this.isConnected) { return; }
 


### PR DESCRIPTION
・ランプとサウンドの命令上限数が間違っていたため、修正しました
・デフォルト引数がCubeクラスと被っていたため、削除しました