### PR TITLE
Add RequestSensor

### DIFF
--- a/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Cube.cs
+++ b/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Cube.cs
@@ -257,6 +257,12 @@ namespace toio
         /// <param name="order">命令の優先度</param>
         public virtual UniTask ConfigMotorRead(bool valid, float timeOutSec = 0.5f, Action<bool,Cube> callback = null, ORDER_TYPE order = ORDER_TYPE.Strong) { NotSupportedWarning(); return UniTask.CompletedTask; }
 
+        /// モーションセンサー情報を要求します
+        /// https://toio.github.io/toio-spec/docs/ble_sensor#書き込み操作
+        /// </summary>
+        /// <param name="order">命令の優先度</param>
+        public virtual void RequestSensor(ORDER_TYPE order = ORDER_TYPE.Strong) { NotSupportedWarning(); }
+
         //_/_/_/_/_/_/_/_/_/_/_/_/_/
         //      コールバック
         //_/_/_/_/_/_/_/_/_/_/_/_/_/

--- a/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Real/Versions/CubeReal_ver2_2_0.cs
+++ b/toio-sdk-unity/Assets/toio-sdk/Scripts/Cube/CoreCube/Real/Versions/CubeReal_ver2_2_0.cs
@@ -154,6 +154,21 @@ namespace toio
             callback?.Invoke(this.motorReadRequest.isConfigResponseSucceeded, this);
         }
 
+        /// <summary>
+        /// モーションセンサー情報を要求します
+        /// https://toio.github.io/toio-spec/docs/ble_sensor#書き込み操作
+        /// </summary>
+        /// <param name="order">命令の優先度</param>
+        public override void RequestSensor(ORDER_TYPE order)
+        {
+            if (!this.isConnected) { return; }
+
+            byte[] buff = new byte[1];
+            buff[0] = 0x81;
+
+            this.Request(CHARACTERISTIC_SENSOR, buff, true, order, "requestSensor");
+        }
+
         //_/_/_/_/_/_/_/_/_/_/_/_/_/_/
         //      CoreCube API < subscribe >
         //_/_/_/_/_/_/_/_/_/_/_/_/_/_/


### PR DESCRIPTION
https://toio.github.io/toio-spec/docs/ble_sensor#書き込み操作
の「モーションセンサー情報の要求」APIを追加させていただきました。

追加の動機は以下の通りです。
一度衝突あり検出した後、衝突なし状態に変わっただけの時にはtoioキューブからの通知が来ないようでして、そのままではCubeクラスの内部状態は衝突あり（toio.Cube.isCollisionDetected=true）のままで、次に衝突あり検出の通知が来てもcollisionCallbackが呼ばれなくなっていました。
そのため、改めて衝突なし状態の任意のタイミングで書き込み操作を行って、1回通知をさせることで、Cubeクラスの内部状態を更新し、次の衝突あり検出に備えたいという意図となります。

なお、当方の確認環境がWebGLしかないため、CubeReal.RequestのwithResponse引数の適切性は把握できておりません。
おそれいりますがご確認いただけますと幸いです。

また、シミュレータ環境につきましては、Inspectorのチェックボックスをオフにした時も期待通りにコールバックが呼ばれていますので、一旦対応しておりません。