### PR TITLE
CubeInteraction targetCamera

### DIFF
--- a/toio-sdk-unity/Assets/toio-sdk/Scripts/Simulator/CubeInteraction.cs
+++ b/toio-sdk-unity/Assets/toio-sdk/Scripts/Simulator/CubeInteraction.cs
@@ -14,6 +14,9 @@ namespace toio.Simulator
         // === Global ===
         public static Object current { get; set; }　// currently object under interaction
 
+        [SerializeField]
+        public Camera targetCamera;
+
         CubeSimulator cube;
         Rigidbody rb;
 
@@ -253,7 +256,7 @@ namespace toio.Simulator
             cubeIndicator.eulerAngles = cube.transform.eulerAngles;
 
             // Following mouse
-            var camera = Camera.main;
+            var camera = targetCamera != null ? targetCamera : Camera.main;
             Ray ray = camera.ScreenPointToRay(Input.mousePosition);
             var hits = Physics.RaycastAll(ray);
             System.Array.Sort(hits, (x,y) => x.distance.CompareTo(y.distance));
@@ -343,7 +346,7 @@ namespace toio.Simulator
 
         void PullCube()
         {
-            var camera = Camera.main;
+            var camera = targetCamera != null ? targetCamera : Camera.main;
             Ray ray = camera.ScreenPointToRay(Input.mousePosition);
             var t = (pullInitialY - ray.origin.y) / ray.direction.y;
             Vector3 dragEndPos = new Vector3(


### PR DESCRIPTION
CubeInteractionで使うCameraを設定できるようにしました。
未設定の場合、現行通りCamera.mainを使います。

画像のようにシミュレータ環境（Stage Prefab）とゲーム画面で別々のCameraを使って、シミュレータ画面をワイプ状に表示しているのですが、両方ともMainCamera tagとしているため、 CubeInteraction 内の Raycast している Camera.main がゲーム画面側のカメラを取得して、ワイプ画面で持ち上げたシミュレータキューブが Stage Prefab から遠く離れたゲーム画面の方に移動してしまうことがありました。
![image](https://user-images.githubusercontent.com/29687119/128628627-ee959443-1627-43b8-86e5-2e2be06a8b5b.png)

Camera.main の仕様に則ると、ゲーム画面側の Camera から MainCamera tag を外すのも有りなのですが、
他でも Camera.main を取り扱う処理が生じてバッティングしないとも限らないので、
そのため、 CubeInteraction に targetCamera を設定したら、それが優先的に使われるようにできれば…という感じです。