### PR TITLE
Fix typo in docs `sys_navigator.md`

### DIFF
--- a/docs/sys_navigator.md
+++ b/docs/sys_navigator.md
@@ -108,7 +108,7 @@ CubeHandle では以下のようなことを行います。 (詳細は usage_cub
 
 - `CubeHandle.Update` メソッドが Cube の情報を取得し、状態予測を行う
 - `CubeHandle.Move2Target` メソッドが、 目標 を入力として受けとり、移動命令を計算する
-- 出力された移動命令を `CubeHandle.Move` メソッドもしくは `Movemnet.Exec` メソッドで実行する
+- 出力された移動命令を `CubeHandle.Move` メソッドもしくは `Movement.Exec` メソッドで実行する
 
 ### 3.1.2. CubeNavigator の制御ブロック図
 
@@ -122,7 +122,7 @@ CubeNavigator では、 Navigator と CubeHandle を組み合わせて
 1. `CubeHandle.Update` メソッドを呼び出し、予測結果と元情報を CubeEntity にセットする (`CubeNavigator.Update` メソッド)
 2. Navigator のナビゲーションアルゴリズムを実行する
 3. ナビゲーションの結果（ウェイポイント座標、速度）を `CubeHandle.Move2Target` メソッドに与えて移動命令を計算する (`CubeNavigator.Navi2Target, CubeNavigator.NaviAwayTarget` メソッド)
-4. 出力された移動命令を `CubeHandle.Move` メソッドもしくは `Movemnet.Exec` メソッドで実行する
+4. 出力された移動命令を `CubeHandle.Move` メソッドもしくは `Movement.Exec` メソッドで実行する
 
 という手順でキューブを制御しています。
 

--- a/docs_EN/sys_navigator.md
+++ b/docs_EN/sys_navigator.md
@@ -106,7 +106,7 @@ CubeHandle does the following. (See usage_cubehandle.md for details.)
 
 - `CubeHandle.Update` method gets information about Cube and predicts its state
 - `CubeHandle.Move2Target` The method takes the target as input and computes the move instruction.
-- Execute the output move instruction with the `CubeHandle.Move` or `Movemnet.Exec` method.
+- Execute the output move instruction with the `CubeHandle.Move` or `Movement.Exec` method.
 
 ### 3.1.2. Control block diagram of CubeNavigator
 
@@ -120,7 +120,7 @@ CubeNavigator uses a combination of Navigator and CubeHandle to control Cube usi
 1. Call the `CubeHandle.Update` method to set the prediction result and source information to CubeEntity (`CubeNavigator.Update` method)
 2. Running the Navigator's navigation algorithm
 3. Give the navigation result (waypoint coordinates, speed) to the `CubeHandle.Move2Target` method to calculate the move instruction (`CubeNavigator.Navi2Target, CubeNavigator.NaviAwayTarget` methods)
-4. Execute the output move instruction with the `CubeHandle.Move` or `Movemnet.Exec` method.
+4. Execute the output move instruction with the `CubeHandle.Move` or `Movement.Exec` method.
 
 ## 3.2. Explanation of internal processing
 


### PR DESCRIPTION
ドキュメントの typo を修正しました。

## 修正内容

- ドキュメント `sys_navigator.md` 内の typo
